### PR TITLE
Allows to control the image content alignment.

### DIFF
--- a/lib/flutter_tex_js.dart
+++ b/lib/flutter_tex_js.dart
@@ -115,6 +115,7 @@ class TexImage extends StatefulWidget {
     this.placeholder,
     this.error,
     this.keepAlive = true,
+    this.alignment = Alignment.center,
     Key? key,
   }) : super(key: key);
 
@@ -146,6 +147,9 @@ class TexImage extends StatefulWidget {
   /// Whether or not the rendered image should be retained even when e.g. the
   /// widget has been scrolled out of view in a [ListView].
   final bool keepAlive;
+
+  /// Controls the content alignment.
+  final AlignmentGeometry alignment;
 
   @override
   _TexImageState createState() => _TexImageState();
@@ -228,6 +232,7 @@ class _TexImageState extends State<TexImage>
             if (snapshot.hasData) {
               return Image.memory(
                 snapshot.data!,
+                alignment: widget.alignment,
                 scale: MediaQuery.of(context).devicePixelRatio,
               );
             } else if (snapshot.hasError) {


### PR DESCRIPTION
A use case could be when `flutter_tex_js` is used to render HTML content. For instance :

<img height="400" src="https://user-images.githubusercontent.com/3882599/110513167-38f06e80-8106-11eb-834d-2d52c269338a.png">

is more beautiful than :

<img height="400" src="https://user-images.githubusercontent.com/3882599/110513173-3a219b80-8106-11eb-8248-01c778385260.png">